### PR TITLE
documentation bug

### DIFF
--- a/src/layout/locator/InputPortLocator.js
+++ b/src/layout/locator/InputPortLocator.js
@@ -6,7 +6,7 @@
  * (source), middle, or end (target) of the Connection.
  *
  * @author Andreas Herz
- * @extend draw2d.layout.locator.Locator
+ * @extend draw2d.layout.locator.PortLocator
  */
 import draw2d from '../../packages'
 

--- a/src/layout/locator/OutputPortLocator.js
+++ b/src/layout/locator/OutputPortLocator.js
@@ -6,7 +6,7 @@
  * (source), middle, or end (target) of the Connection.
  *
  * @author Andreas Herz
- * @extend draw2d.layout.locator.Locator
+ * @extend draw2d.layout.locator.PortLocator
  */
 import draw2d from '../../packages'
 


### PR DESCRIPTION
Just a minor documentation bug. Classes inheriting from PortLocator state wrong parent class.