### PR TITLE
Fix for canvas.setCurrentSelection()

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -1202,8 +1202,8 @@ draw2d.Canvas = Class.extend(
      **/
     setCurrentSelection: function (object) {
       // deselect the current selected figures
-      //
-      this.selection.each( (i, e) =>{
+      // "getAll()" method serve to pass all elements of the original list
+      this.selection.getAll().each( (i, e) =>{
         this.editPolicy.each( (i, policy) =>{
           if (typeof policy.unselect === "function") {
             policy.unselect(this, e)


### PR DESCRIPTION
The `Canvas.setCurrentSelection` method could not make all elements unselected. Because  `this.selection.each` method remove from items from `this.selection` and some last items stay selected.