### PR TITLE
correct dashArray view on polygon

### DIFF
--- a/src/shape/basic/Polygon.js
+++ b/src/shape/basic/Polygon.js
@@ -141,6 +141,9 @@ draw2d.shape.basic.Polygon = draw2d.VectorFigure.extend({
 
     jsonUtil.ensureDefault(attributes, "path", this.svgPathString)
 
+    if (this.dasharray !== null) {
+      attributes["stroke-dasharray"] = this.dasharray;
+    }
     this._super(attributes)
   },
 


### PR DESCRIPTION
Before this change, when you setDashArray to polygon, the stroke of polygon don't change style.
