### PR TITLE
Added 'target' to connection 'dragend' event

### DIFF
--- a/src/policy/connection/DragConnectionCreatePolicy.js
+++ b/src/policy/connection/DragConnectionCreatePolicy.js
@@ -232,7 +232,7 @@ draw2d.policy.connection.DragConnectionCreatePolicy = draw2d.policy.connection.C
 
             // fire an event
             // @since 5.3.3
-            de.fireEvent("dragend",{x:x, y:y, shiftKey:shiftKey, ctrlKey:ctrlKey});
+            de.fireEvent("dragend",{x:x, y:y, shiftKey:shiftKey, ctrlKey:ctrlKey, target: ct});
 
 
             // check if we drop the port onto a valid


### PR DESCRIPTION
Added a 'target' value passed alongside the 'dragend' event of connections. This allows detecting when the 'drop' is ended on nothing. Used to open a menu at that point, like Unreal Engine does with blueprints